### PR TITLE
Add support for pkg-config to the common build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
+# Run pkg-config with the modules in the BUILD_PKG_CONFIG_MODULES environment variable, if this 
+# variable exists.
+function pkg_config_flags {
+    if [[ -n "$BUILD_PKG_CONFIG_MODULES" ]]; then
+        pkg-config --libs --cflags $BUILD_PKG_CONFIG_MODULES
+    fi
+}
+
 function build_linux_macos()
 {
-  #g++ pilot_episode.cpp -lSDL2 -o pilot_episode
-  #g++ pilot_episode.cpp -lncurses -o pilot_episode
-  #export XDG_RUNTIME_DIR=/tmp
   echo "Building for Linux / MacOS target..."
   mkdir -p bin_linux
-  build_cmd="g++ $1.cpp -o ./bin_linux/$1 -std=c++2a -O3 $2"
+  build_cmd="g++ $1.cpp -o ./bin_linux/$1 -std=c++2a -O2 $(pkg_config_flags) $2"
   echo $build_cmd
+
   $build_cmd
-  #g++ $1.cpp -o ./bin_linux/$1 -std=c++2a -O3 $2
+
   echo "Done."
-  #./pilot_episode
 }
 
 function build_windows()


### PR DESCRIPTION
This PR adds and uses a function in the `build.sh` that will run `pkg-config` with the modules listed in the `BUILD_PKG_CONFIG_MODULES` (this variable is intended to be set in project-specific `build.sh` scripts). 

- `pkg-config` will also be used on the macos build. I am not sure whether this will work though, but at least it seems that pkg-config can be installed using homebrew.
- I have removed some commented out code, tell me if you want it back @razterizer 
- I have also switched the optimization level to `-O2` because IIRC `-O3` enables very aggressive optimizations that can potentially create bugs.